### PR TITLE
ndarray の利用箇所を抽象化

### DIFF
--- a/projects/neural_network/examples/learning_mnist.rs
+++ b/projects/neural_network/examples/learning_mnist.rs
@@ -1,5 +1,6 @@
 extern crate neural_network;
 
+use ndarray::{Array1, Array2};
 use neural_network::{
     dataset::{
         dataset::{Dataset, MiniBatch},
@@ -29,7 +30,7 @@ fn main() {
         test_image_file_path: "data/t10k-images-idx3-ubyte",
         test_label_file_path: "data/t10k-labels-idx1-ubyte",
     };
-    let mut mnist_dataset = MnistDataset::new(params);
+    let mut mnist_dataset: MnistDataset<Array2<f32>, Array1<f32>> = MnistDataset::new(params);
 
     // 入力サイズの取得
     let input_size = 28 * 28;
@@ -54,6 +55,7 @@ fn main() {
         for MiniBatch {
             bundled_inputs,
             bundled_one_hot_labels,
+            ph: _,
         } in &mut mnist_dataset
         {
             network.forward(bundled_inputs, bundled_one_hot_labels);
@@ -65,6 +67,7 @@ fn main() {
         let MiniBatch {
             bundled_one_hot_labels,
             bundled_inputs,
+            ph: _,
         } = mnist_dataset.test_data();
 
         // テストデータのデータ数の取得

--- a/projects/neural_network/examples/learning_mnist_with_trainer.rs
+++ b/projects/neural_network/examples/learning_mnist_with_trainer.rs
@@ -1,3 +1,4 @@
+use ndarray::{Array1, Array2};
 use neural_network::{
     dataset::imp::mnist::{InitParamsOfMnistDataset, MnistDataset},
     network::simple_network::{Activation, SimpleNetwork},
@@ -21,7 +22,7 @@ fn main() {
         test_image_file_path: "data/t10k-images-idx3-ubyte",
         test_label_file_path: "data/t10k-labels-idx1-ubyte",
     };
-    let mut dataset = MnistDataset::new(params);
+    let mut dataset: MnistDataset<Array2<f32>, Array1<f32>> = MnistDataset::new(params);
 
     let network = SimpleNetwork::new(28 * 28, HIDDNE_SIZES.to_vec(), 10, Activation::ReLU);
     let optimizer = SGD::new(LearningRate::new(LEARNING_RATE));

--- a/projects/neural_network/examples/learning_spiral.rs
+++ b/projects/neural_network/examples/learning_spiral.rs
@@ -1,5 +1,6 @@
 extern crate neural_network;
 
+use ndarray::{Array1, Array2};
 use neural_network::{
     dataset::{
         dataset::{Dataset, MiniBatch},
@@ -30,7 +31,7 @@ fn main() {
         max_angle: 1.5 * std::f32::consts::PI,
         batch_size: BATCH_SIZE,
     };
-    let mut spiral_dataset = SpiralDataset::new(config);
+    let mut spiral_dataset: SpiralDataset<Array2<f32>, Array1<f32>> = SpiralDataset::new(config);
 
     // 入力サイズの取得
     let input_size = 2;
@@ -57,6 +58,7 @@ fn main() {
         for MiniBatch {
             bundled_inputs,
             bundled_one_hot_labels,
+            ph: _,
         } in &mut spiral_dataset
         {
             network.forward(bundled_inputs, bundled_one_hot_labels);
@@ -68,6 +70,7 @@ fn main() {
         let MiniBatch {
             bundled_one_hot_labels,
             bundled_inputs,
+            ph: _,
         } = spiral_dataset.test_data();
 
         // テストデータのデータ数の取得

--- a/projects/neural_network/examples/learning_spiral_with_trainer.rs
+++ b/projects/neural_network/examples/learning_spiral_with_trainer.rs
@@ -1,3 +1,4 @@
+use ndarray::{Array2, Array1};
 use neural_network::{
     dataset::imp::spiral::{InitParamsOfSpiralDataset, SpiralDataset},
     network::{self, simple_network::Activation},
@@ -20,7 +21,7 @@ fn main() {
         point_per_class: 100,
         max_angle: 1. * std::f32::consts::PI,
     };
-    let mut dataset = SpiralDataset::new(params);
+    let mut dataset: SpiralDataset<Array2<f32>, Array1<f32>> = SpiralDataset::new(params);
 
     let network = network::simple_network::SimpleNetwork::new(
         2,

--- a/projects/neural_network/examples/view_spiral_data.rs
+++ b/projects/neural_network/examples/view_spiral_data.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use ndarray::{Array1, Array2};
 use neural_network::dataset::imp::spiral::{InitParamsOfSpiralDataset, SpiralDataset};
 use plotters::prelude::*;
 
@@ -11,7 +12,7 @@ fn main() -> Result<()> {
         max_angle: 2.0 * std::f32::consts::PI,
         batch_size: 30,
     };
-    let spiral_dataset = SpiralDataset::new(params);
+    let spiral_dataset: SpiralDataset<Array2<f32>, Array1<f32>> = SpiralDataset::new(params);
 
     let series = spiral_dataset.get_points();
 

--- a/projects/neural_network/src/dataset/dataset.rs
+++ b/projects/neural_network/src/dataset/dataset.rs
@@ -1,7 +1,5 @@
 use std::marker::PhantomData;
 
-use ndarray::Array2;
-
 use crate::matrix::{matrix_one_dim::MatrixOneDim, matrix_two_dim::MatrixTwoDim};
 
 pub trait Dataset<M2, M1>: ExactSizeIterator<Item = MiniBatch<M2, M1>>

--- a/projects/neural_network/src/dataset/dataset.rs
+++ b/projects/neural_network/src/dataset/dataset.rs
@@ -1,11 +1,24 @@
+use std::marker::PhantomData;
+
 use ndarray::Array2;
 
-pub trait Dataset: ExactSizeIterator<Item = MiniBatch> {
+use crate::matrix::{matrix_one_dim::MatrixOneDim, matrix_two_dim::MatrixTwoDim};
+
+pub trait Dataset<M2, M1>: ExactSizeIterator<Item = MiniBatch<M2, M1>>
+where
+    M2: MatrixTwoDim<M1>,
+    M1: MatrixOneDim,
+{
     fn shuffle_and_reset_cursor(&mut self);
-    fn test_data(&self) -> MiniBatch;
+    fn test_data(&self) -> MiniBatch<M2, M1>;
 }
 
-pub struct MiniBatch {
-    pub bundled_inputs: Array2<f32>,
-    pub bundled_one_hot_labels: Array2<f32>,
+pub struct MiniBatch<M2, M1>
+where
+    M2: MatrixTwoDim<M1>,
+    M1: MatrixOneDim,
+{
+    pub bundled_inputs: M2,
+    pub bundled_one_hot_labels: M2,
+    pub ph: PhantomData<M1>,
 }

--- a/projects/neural_network/src/dataset/imp/mnist/image_with_class.rs
+++ b/projects/neural_network/src/dataset/imp/mnist/image_with_class.rs
@@ -1,7 +1,5 @@
 use std::{fs::File, io::Read, marker::PhantomData};
 
-use ndarray::{Array1, Array2};
-
 mod one_hot_label;
 use crate::{
     dataset::dataset::MiniBatch,

--- a/projects/neural_network/src/dataset/imp/mnist/image_with_class.rs
+++ b/projects/neural_network/src/dataset/imp/mnist/image_with_class.rs
@@ -1,22 +1,31 @@
-use std::{fs::File, io::Read};
+use std::{fs::File, io::Read, marker::PhantomData};
 
 use ndarray::{Array1, Array2};
 
 mod one_hot_label;
-use crate::dataset::dataset::MiniBatch;
+use crate::{
+    dataset::dataset::MiniBatch,
+    matrix::{matrix_one_dim::MatrixOneDim, matrix_two_dim::MatrixTwoDim},
+};
 
 use self::one_hot_label::OneHotLabel;
 
-pub(super) struct ImageWithClass {
-    image: Array1<f32>,
-    class: OneHotLabel,
+pub(super) struct ImageWithClass<M2, M1> {
+    image: M1,
+    class: OneHotLabel<M1>,
+    ph: PhantomData<M2>,
 }
 
-impl ImageWithClass {
+impl<M2, M1> ImageWithClass<M2, M1>
+where
+    M2: MatrixTwoDim<M1>,
+    M1: MatrixOneDim,
+{
     fn new(image_pixels: &[u8], label: u8) -> Self {
+        let image_pixels = image_pixels.iter().map(|x| *x as f32).collect::<Vec<f32>>();
         let class = OneHotLabel::new(label as usize, 10);
-        let image = Array1::from(image_pixels.to_vec()).mapv(|x| x as f32);
-        Self { image, class }
+        let image = M1::from(image_pixels).mapv_into(|x| x as f32);
+        Self { image, class, ph: PhantomData }
     }
 
     pub(super) fn load_from_files(
@@ -73,7 +82,7 @@ impl ImageWithClass {
         let number_of_columns = u32::from_be_bytes(buf) as usize;
         println!("Image Height: {}", number_of_columns);
 
-        let mut images = Vec::<ImageWithClass>::with_capacity(number_of_images as usize);
+        let mut images = Vec::<ImageWithClass<M2, M1>>::with_capacity(number_of_images as usize);
 
         // ラベルの読み出し
         let mut labels: Vec<u8> = Vec::with_capacity(number_of_images);
@@ -109,43 +118,28 @@ impl ImageWithClass {
     }
 }
 
-impl MiniBatch {
-    pub(super) fn from_images(images: &[ImageWithClass]) -> Self {
-        let bundled_points: Vec<Array1<f32>> = images
+impl<M2, M1> MiniBatch<M2, M1>
+where
+    M2: MatrixTwoDim<M1>,
+    M1: MatrixOneDim,
+{
+    pub(super) fn from_images(images: &[ImageWithClass<M2, M1>]) -> Self {
+        let bundled_points: Vec<M1> = images
             .iter()
             .map(|image_with_class| image_with_class.image.clone())
             .collect();
-        let bundled_inputs = bundle_1d_arrays_into_2d_array(bundled_points);
+        let bundled_inputs = M2::from_1d_arrays(bundled_points);
 
-        let bundled_one_hot_labels: Vec<Array1<f32>> = images
+        let bundled_one_hot_labels: Vec<M1> = images
             .iter()
             .map(|image_with_class| image_with_class.class.get_array())
             .collect();
-        let bundled_one_hot_labels = bundle_1d_arrays_into_2d_array(bundled_one_hot_labels);
+        let bundled_one_hot_labels = M2::from_1d_arrays(bundled_one_hot_labels);
 
         Self {
             bundled_inputs,
             bundled_one_hot_labels,
+            ph: PhantomData,
         }
     }
-}
-
-fn bundle_1d_arrays_into_2d_array<T>(arrays: Vec<Array1<T>>) -> Array2<T>
-where
-    T: Clone,
-{
-    // ソースに１つ以上の１次元配列が含まれることを要請
-    let width = arrays.len();
-    assert!(width > 0);
-
-    // すべての1次元配列の長さが等しいことを要請
-    let height = arrays[0].len();
-    assert!(arrays.iter().all(|array| { array.len() == height }));
-
-    // １次元配列をすべて連結
-    let flattened: Array1<T> = arrays.into_iter().flat_map(|row| row.to_vec()).collect();
-
-    // 連結した１次元配列を２次元配列に変換
-    let output = flattened.into_shape((width, height)).unwrap();
-    output
 }

--- a/projects/neural_network/src/dataset/imp/mnist/image_with_class/one_hot_label.rs
+++ b/projects/neural_network/src/dataset/imp/mnist/image_with_class/one_hot_label.rs
@@ -1,5 +1,3 @@
-use ndarray::Array1;
-
 use crate::matrix::matrix_one_dim::MatrixOneDim;
 
 pub(super) struct OneHotLabel<M1>(M1);

--- a/projects/neural_network/src/dataset/imp/mnist/image_with_class/one_hot_label.rs
+++ b/projects/neural_network/src/dataset/imp/mnist/image_with_class/one_hot_label.rs
@@ -1,16 +1,21 @@
 use ndarray::Array1;
 
-pub(super) struct OneHotLabel(Array1<f32>);
+use crate::matrix::matrix_one_dim::MatrixOneDim;
 
-impl OneHotLabel {
+pub(super) struct OneHotLabel<M1>(M1);
+
+impl<M1> OneHotLabel<M1>
+where
+    M1: MatrixOneDim,
+{
     pub(super) fn new(class: usize, number_of_class: usize) -> Self {
         assert!(class < number_of_class);
         let mut label = vec![0.; number_of_class];
         label[class] = 1.;
-        Self(Array1::from(label))
+        Self(M1::from(label))
     }
 
-    pub(super) fn get_array(&self) -> Array1<f32> {
+    pub(super) fn get_array(&self) -> M1 {
         self.0.clone()
     }
 }

--- a/projects/neural_network/src/dataset/imp/spiral.rs
+++ b/projects/neural_network/src/dataset/imp/spiral.rs
@@ -15,7 +15,7 @@ pub struct SpiralDataset<M2, M1> {
     points: Vec<PointWithClass<M1>>,
     cursor: usize,
     batch_size: usize,
-    phantom: PhantomData<(M2)>,
+    phantom: PhantomData<M2>,
 }
 
 pub struct InitParamsOfSpiralDataset {

--- a/projects/neural_network/src/dataset/imp/spiral.rs
+++ b/projects/neural_network/src/dataset/imp/spiral.rs
@@ -1,17 +1,21 @@
 mod point_with_class;
 
-use std::{collections::HashMap, f32::consts::PI};
+use std::{collections::HashMap, f32::consts::PI, marker::PhantomData};
 
 use rand::seq::SliceRandom;
 
-use crate::dataset::dataset::{Dataset, MiniBatch};
+use crate::{
+    dataset::dataset::{Dataset, MiniBatch},
+    matrix::{matrix_one_dim::MatrixOneDim, matrix_two_dim::MatrixTwoDim},
+};
 
 use self::point_with_class::PointWithClass;
 
-pub struct SpiralDataset {
-    points: Vec<PointWithClass>,
+pub struct SpiralDataset<M2, M1> {
+    points: Vec<PointWithClass<M1>>,
     cursor: usize,
     batch_size: usize,
+    phantom: PhantomData<(M2)>,
 }
 
 pub struct InitParamsOfSpiralDataset {
@@ -21,7 +25,11 @@ pub struct InitParamsOfSpiralDataset {
     pub max_angle: f32,
 }
 
-impl SpiralDataset {
+impl<M2, M1> SpiralDataset<M2, M1>
+where
+    M2: MatrixTwoDim<M1>,
+    M1: MatrixOneDim,
+{
     pub fn new(params: InitParamsOfSpiralDataset) -> Self {
         let InitParamsOfSpiralDataset {
             batch_size,
@@ -49,6 +57,7 @@ impl SpiralDataset {
             points,
             cursor: 0,
             batch_size,
+            phantom: PhantomData,
         }
     }
 
@@ -62,19 +71,27 @@ impl SpiralDataset {
     }
 }
 
-impl Dataset for SpiralDataset {
+impl<M2, M1> Dataset<M2, M1> for SpiralDataset<M2, M1>
+where
+    M2: MatrixTwoDim<M1>,
+    M1: MatrixOneDim,
+{
     fn shuffle_and_reset_cursor(&mut self) {
         self.points.shuffle(&mut rand::thread_rng());
         self.cursor = 0;
     }
 
-    fn test_data(&self) -> MiniBatch {
+    fn test_data(&self) -> MiniBatch<M2, M1> {
         MiniBatch::from_points(&self.points)
     }
 }
 
-impl Iterator for SpiralDataset {
-    type Item = MiniBatch;
+impl<M2, M1> Iterator for SpiralDataset<M2, M1>
+where
+    M2: MatrixTwoDim<M1>,
+    M1: MatrixOneDim,
+{
+    type Item = MiniBatch<M2, M1>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let number_of_points = self.points.len();
@@ -90,7 +107,11 @@ impl Iterator for SpiralDataset {
     }
 }
 
-impl  ExactSizeIterator for SpiralDataset {
+impl<M2, M1> ExactSizeIterator for SpiralDataset<M2, M1>
+where
+    M2: MatrixTwoDim<M1>,
+    M1: MatrixOneDim,
+{
     fn len(&self) -> usize {
         self.points.len() / self.batch_size
     }

--- a/projects/neural_network/src/dataset/imp/spiral/point_with_class.rs
+++ b/projects/neural_network/src/dataset/imp/spiral/point_with_class.rs
@@ -1,17 +1,25 @@
 mod one_hot_label;
+use std::marker::PhantomData;
+
 use ndarray::{array, Array1, Array2};
 
-use crate::dataset::dataset::MiniBatch;
+use crate::{
+    dataset::dataset::MiniBatch,
+    matrix::{matrix_one_dim::MatrixOneDim, matrix_two_dim::MatrixTwoDim},
+};
 
 use self::one_hot_label::OneHotLabel;
 
-pub(super) struct PointWithClass {
+pub(super) struct PointWithClass<M1> {
     x: f32,
     y: f32,
-    class: OneHotLabel,
+    class: OneHotLabel<M1>,
 }
 
-impl PointWithClass {
+impl<M1> PointWithClass<M1>
+where
+    M1: MatrixOneDim,
+{
     pub(super) fn new(x: f32, y: f32, class: usize, class_number: usize) -> Self {
         Self {
             x,
@@ -29,41 +37,26 @@ impl PointWithClass {
     }
 }
 
-impl MiniBatch {
-    pub(super) fn from_points(points: &[PointWithClass]) -> Self {
-        let bundled_points: Vec<Array1<f32>> = points
+impl<M2, M1> MiniBatch<M2, M1>
+where
+    M2: MatrixTwoDim<M1>,
+    M1: MatrixOneDim,
+{
+    pub(super) fn from_points(points: &[PointWithClass<M1>]) -> Self {
+        let bundled_points: Vec<M1> = points
             .iter()
-            .map(|point| array![point.x, point.y])
+            .map(|point| M1::from(vec![point.x, point.y]))
             .collect();
-        let bundled_inputs = bundle_1d_arrays_into_2d_array(bundled_points);
+        let bundled_inputs = M2::from_1d_arrays(bundled_points);
 
-        let bundled_one_hot_labels: Vec<Array1<f32>> =
+        let bundled_one_hot_labels: Vec<M1> =
             points.iter().map(|point| point.class.get_array()).collect();
-        let bundled_one_hot_labels = bundle_1d_arrays_into_2d_array(bundled_one_hot_labels);
+        let bundled_one_hot_labels = M2::from_1d_arrays(bundled_one_hot_labels);
 
         Self {
             bundled_inputs,
             bundled_one_hot_labels,
+            ph: PhantomData,
         }
     }
-}
-
-fn bundle_1d_arrays_into_2d_array<T>(arrays: Vec<Array1<T>>) -> Array2<T>
-where
-    T: Clone,
-{
-    // ソースに１つ以上の１次元配列が含まれることを要請
-    let width = arrays.len();
-    assert!(width > 0);
-
-    // すべての1次元配列の長さが等しいことを要請
-    let height = arrays[0].len();
-    assert!(arrays.iter().all(|array| { array.len() == height }));
-
-    // １次元配列をすべて連結
-    let flattened: Array1<T> = arrays.into_iter().flat_map(|row| row.to_vec()).collect();
-
-    // 連結した１次元配列を２次元配列に変換
-    let output = flattened.into_shape((width, height)).unwrap();
-    output
 }

--- a/projects/neural_network/src/dataset/imp/spiral/point_with_class.rs
+++ b/projects/neural_network/src/dataset/imp/spiral/point_with_class.rs
@@ -1,8 +1,6 @@
 mod one_hot_label;
 use std::marker::PhantomData;
 
-use ndarray::{array, Array1, Array2};
-
 use crate::{
     dataset::dataset::MiniBatch,
     matrix::{matrix_one_dim::MatrixOneDim, matrix_two_dim::MatrixTwoDim},

--- a/projects/neural_network/src/dataset/imp/spiral/point_with_class/one_hot_label.rs
+++ b/projects/neural_network/src/dataset/imp/spiral/point_with_class/one_hot_label.rs
@@ -1,5 +1,3 @@
-use ndarray::Array1;
-
 use crate::matrix::matrix_one_dim::MatrixOneDim;
 
 pub(super) struct OneHotLabel<M1>(M1);

--- a/projects/neural_network/src/dataset/imp/spiral/point_with_class/one_hot_label.rs
+++ b/projects/neural_network/src/dataset/imp/spiral/point_with_class/one_hot_label.rs
@@ -1,25 +1,25 @@
 use ndarray::Array1;
 
-pub(super) struct OneHotLabel(Array1<f32>);
+use crate::matrix::matrix_one_dim::MatrixOneDim;
 
-impl OneHotLabel {
+pub(super) struct OneHotLabel<M1>(M1);
+
+impl<M1> OneHotLabel<M1>
+where
+    M1: MatrixOneDim,
+{
     pub(super) fn new(class: usize, number_of_class: usize) -> Self {
         assert!(class < number_of_class);
         let mut label = vec![0.; number_of_class];
         label[class] = 1.;
-        Self(Array1::from(label))
+        Self(M1::from(label))
     }
 
-    pub(super) fn get_array(&self) -> Array1<f32> {
+    pub(super) fn get_array(&self) -> M1 {
         self.0.clone()
     }
 
     pub(super) fn get_class(&self) -> usize {
-        self.0
-            .iter()
-            .enumerate()
-            .find(|&(_index, &class)| class == 1.)
-            .map(|(index, _)| index)
-            .unwrap()
+        self.0.find_index(|element| element == 1.).unwrap()
     }
 }

--- a/projects/neural_network/src/layers/add.rs
+++ b/projects/neural_network/src/layers/add.rs
@@ -1,30 +1,38 @@
+use std::marker::PhantomData;
+
 use ndarray::Array2;
+
+use crate::matrix::{matrix_two_dim::MatrixTwoDim, matrix_one_dim::MatrixOneDim};
 
 use super::layer::Layer;
 
-struct Add {}
+struct Add<M2, M1>(PhantomData<M2>, PhantomData<M1>);
 
-struct InputOfAddLayer {
-    a: Array2<f32>,
-    b: Array2<f32>,
+struct InputOfAddLayer<M2> {
+    a: M2,
+    b: M2,
 }
 
-struct OutputOfAddLayer {
-    out: Array2<f32>,
+struct OutputOfAddLayer<M2> {
+    out: M2,
 }
 
-struct DInputOfAddLayer {
-    da: Array2<f32>,
-    db: Array2<f32>,
+struct DInputOfAddLayer<M2> {
+    da: M2,
+    db: M2,
 }
 
-impl Layer for Add {
-    type Input = InputOfAddLayer;
-    type Output = OutputOfAddLayer;
-    type DInput = DInputOfAddLayer;
+impl<M2, M1> Layer<M2, M1> for Add<M2, M1>
+where
+    M2: MatrixTwoDim<M1>,
+    M1: MatrixOneDim,
+{
+    type Input = InputOfAddLayer<M2>;
+    type Output = OutputOfAddLayer<M2>;
+    type DInput = DInputOfAddLayer<M2>;
 
     fn new() -> Self {
-        Self {}
+        Self(PhantomData, PhantomData)
     }
 
     fn forward(&mut self, input: Self::Input) -> Self::Output {
@@ -43,14 +51,14 @@ impl Layer for Add {
 
 #[cfg(test)]
 mod tests {
-    use ndarray::array;
+    use ndarray::{array, Array1};
 
     use super::*;
 
     #[test]
     fn test_add_layer() {
         // z = x + y となっていることををチェック
-        let mut add = Add::new();
+        let mut add = Add::<Array2<f32>, Array1<f32>>::new();
         let a = array![[1., 2., 3.], [4., 5., 6.]];
         let b = array![[7., 8., 9.], [10., 11., 12.]];
         let input = InputOfAddLayer { a, b };

--- a/projects/neural_network/src/layers/add.rs
+++ b/projects/neural_network/src/layers/add.rs
@@ -1,7 +1,5 @@
 use std::marker::PhantomData;
 
-use ndarray::Array2;
-
 use crate::matrix::{matrix_two_dim::MatrixTwoDim, matrix_one_dim::MatrixOneDim};
 
 use super::layer::Layer;
@@ -51,7 +49,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use ndarray::{array, Array1};
+    use ndarray::{array, Array1, Array2};
 
     use super::*;
 

--- a/projects/neural_network/src/layers/affine.rs
+++ b/projects/neural_network/src/layers/affine.rs
@@ -7,8 +7,6 @@
 
 use std::marker::PhantomData;
 
-use ndarray::{Array1, Array2, Axis};
-
 use crate::matrix::{matrix_one_dim::MatrixOneDim, matrix_two_dim::MatrixTwoDim};
 
 use super::layer::Layer;
@@ -80,8 +78,8 @@ where
         let a = self.a.as_ref().unwrap();
         let Self::Output { out: dout } = dout;
         Self::DInput {
-            dx: dout.dot(&a.clone().t()).to_owned(),
-            da: x.clone().t().dot(&dout).to_owned(),
+            dx: dout.dot(&a.t()).to_owned(),
+            da: x.t().dot(&dout).to_owned(),
             db: dout.sum_axis_zero().to_owned(),
         }
     }

--- a/projects/neural_network/src/layers/branch.rs
+++ b/projects/neural_network/src/layers/branch.rs
@@ -1,7 +1,5 @@
 use std::marker::PhantomData;
 
-use ndarray::Array2;
-
 use crate::matrix::{matrix_one_dim::MatrixOneDim, matrix_two_dim::MatrixTwoDim};
 
 use super::layer::Layer;

--- a/projects/neural_network/src/layers/branch.rs
+++ b/projects/neural_network/src/layers/branch.rs
@@ -1,34 +1,40 @@
+use std::marker::PhantomData;
+
 use ndarray::Array2;
+
+use crate::matrix::{matrix_one_dim::MatrixOneDim, matrix_two_dim::MatrixTwoDim};
 
 use super::layer::Layer;
 
-struct Branch {}
+struct Branch<M2, M1>(PhantomData<M2>, PhantomData<M1>);
 
-struct InputOfBranchLayer {
-    input: Array2<f32>,
+struct InputOfBranchLayer<M2> {
+    input: M2,
 }
 
-struct DInputOfBranchLayer {
-    dinput: Array2<f32>
+struct DInputOfBranchLayer<M2> {
+    dinput: M2,
 }
 
-struct OutputOfBranchLayer {
-    a: Array2<f32>,
-    b: Array2<f32>,
+struct OutputOfBranchLayer<M2> {
+    a: M2,
+    b: M2,
 }
 
-impl Layer for Branch
+impl<M2, M1> Layer<M2, M1> for Branch<M2, M1>
+where
+    M2: MatrixTwoDim<M1>,
+    M1: MatrixOneDim,
 {
-    type Input = InputOfBranchLayer;
-    type Output = OutputOfBranchLayer;
-    type DInput = DInputOfBranchLayer;
+    type Input = InputOfBranchLayer<M2>;
+    type Output = OutputOfBranchLayer<M2>;
+    type DInput = DInputOfBranchLayer<M2>;
 
     fn new() -> Self {
-        Self {}
+        Self(PhantomData, PhantomData)
     }
 
-    fn forward(&mut self, input: Self::Input) -> Self::Output
-    {
+    fn forward(&mut self, input: Self::Input) -> Self::Output {
         Self::Output {
             a: input.input.clone(),
             b: input.input,

--- a/projects/neural_network/src/layers/layer.rs
+++ b/projects/neural_network/src/layers/layer.rs
@@ -1,4 +1,10 @@
-pub(crate)trait Layer {
+use crate::matrix::{matrix_one_dim::MatrixOneDim, matrix_two_dim::MatrixTwoDim};
+
+pub(crate) trait Layer<M2, M1>
+where
+    M2: MatrixTwoDim<M1>,
+    M1: MatrixOneDim,
+{
     type Input;
     type Output;
     type DInput;

--- a/projects/neural_network/src/layers/matrix_multiply.rs
+++ b/projects/neural_network/src/layers/matrix_multiply.rs
@@ -6,8 +6,6 @@
 
 use std::marker::PhantomData;
 
-use ndarray::Array2;
-
 use crate::matrix::{matrix_one_dim::MatrixOneDim, matrix_two_dim::MatrixTwoDim};
 
 use super::layer::Layer;
@@ -42,7 +40,11 @@ where
     type DInput = DInputOfMatMulLayer<M2>;
 
     fn new() -> Self {
-        Self { a: None, x: None, ph: PhantomData }
+        Self {
+            a: None,
+            x: None,
+            ph: PhantomData,
+        }
     }
 
     fn forward(&mut self, input: Self::Input) -> Self::Output {
@@ -61,8 +63,8 @@ where
         let a = self.a.as_ref().unwrap();
         let Self::Output { out: dout } = dout;
         Self::DInput {
-            dx: dout.dot(&a.clone().t()).to_owned(),
-            da: x.clone().t().dot(&dout).to_owned(),
+            dx: dout.dot(&a.t()).to_owned(),
+            da: x.t().dot(&dout).to_owned(),
         }
     }
 }

--- a/projects/neural_network/src/layers/relu.rs
+++ b/projects/neural_network/src/layers/relu.rs
@@ -9,8 +9,6 @@
 
 use std::marker::PhantomData;
 
-use ndarray::{Array1, Array2};
-
 use crate::matrix::{matrix_one_dim::MatrixOneDim, matrix_two_dim::MatrixTwoDim};
 
 use super::layer::Layer;
@@ -95,7 +93,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    use approx::assert_abs_diff_eq;
     use ndarray::array;
 
     use super::*;

--- a/projects/neural_network/src/layers/relu.rs
+++ b/projects/neural_network/src/layers/relu.rs
@@ -7,61 +7,78 @@
             { 0      if x <= 0
 */
 
-use ndarray::{Array2, Array1};
+use std::marker::PhantomData;
+
+use ndarray::{Array1, Array2};
+
+use crate::matrix::{matrix_one_dim::MatrixOneDim, matrix_two_dim::MatrixTwoDim};
 
 use super::layer::Layer;
 
-pub(crate) struct ReLU {
-    filter: Option<Array2<bool>>,
+pub(crate) struct ReLU<M2, M1> {
+    filter: Option<M2>,
+    ph: PhantomData<M1>,
 }
 
-pub(crate) struct InputOfReLULayer {
-    input: Array2<f32>,
+pub(crate) struct InputOfReLULayer<M2> {
+    input: M2,
 }
 
-impl From<Array2<f32>> for InputOfReLULayer {
-    fn from(value: Array2<f32>) -> Self {
+impl<M2> From<M2> for InputOfReLULayer<M2> {
+    fn from(value: M2) -> Self {
         Self { input: value }
     }
 }
 
-pub(crate) struct DInputOfReLULayer {
-    dinput: Array2<f32>,
+pub(crate) struct DInputOfReLULayer<M2> {
+    dinput: M2,
 }
 
-impl Into<Array2<f32>> for DInputOfReLULayer {
-    fn into(self) -> Array2<f32> {
+impl<M2> DInputOfReLULayer<M2> {
+    pub fn into_value(self) -> M2 {
         self.dinput
     }
 }
 
-pub(crate) struct OutputOfReLULayer {
-    out: Array2<f32>,
-}
-
-impl From<Array2<f32>> for OutputOfReLULayer {
-    fn from(value: Array2<f32>) -> Self {
-        Self { out: value }
+impl<M2> From<M2> for DInputOfReLULayer<M2> {
+    fn from(value: M2) -> Self {
+        Self { dinput: value }
     }
 }
 
-impl Into<Array2<f32>> for OutputOfReLULayer {
-    fn into(self) -> Array2<f32> {
+pub(crate) struct OutputOfReLULayer<M2> {
+    out: M2,
+}
+
+impl<M2> OutputOfReLULayer<M2> {
+    pub fn into_value(self) -> M2 {
         self.out
     }
 }
 
-impl Layer for ReLU {
-    type Input = InputOfReLULayer;
-    type Output = OutputOfReLULayer;
-    type DInput = DInputOfReLULayer;
+impl<M2> From<M2> for OutputOfReLULayer<M2> {
+    fn from(value: M2) -> Self {
+        Self { out: value }
+    }
+}
+
+impl<M2, M1> Layer<M2, M1> for ReLU<M2, M1>
+where
+    M2: MatrixTwoDim<M1>,
+    M1: MatrixOneDim,
+{
+    type Input = InputOfReLULayer<M2>;
+    type Output = OutputOfReLULayer<M2>;
+    type DInput = DInputOfReLULayer<M2>;
     fn new() -> Self {
-        Self { filter: None }
+        Self { filter: None, ph: PhantomData }
     }
 
     fn forward(&mut self, input: Self::Input) -> Self::Output {
         let Self::Input { input } = input;
-        let filter = input.clone().mapv_into_any(|x| if x > 0. { true } else { false });
+        let filter = input
+            .clone()
+            .mapv_into(|x| if x > 0. { 1. } else { 0. });
         self.filter = Some(filter);
         let out = input.mapv_into(|x| if x > 0. { x } else { 0. });
         Self::Output { out }
@@ -71,15 +88,7 @@ impl Layer for ReLU {
         assert!(self.filter.is_some());
         let filter = self.filter.as_ref().unwrap();
         let Self::Output { out: dout } = dout;
-
-        let dinput_1d: Array1<f32> = dout.into_iter().zip(filter).map(|(dout, filter)| {
-            if *filter {
-                dout
-            } else {
-                0.
-            }
-        }).collect();
-        let dinput = dinput_1d.into_shape((filter.shape()[0], filter.shape()[1])).unwrap();
+        let dinput = dout * filter.clone();
         Self::DInput { dinput }
     }
 }

--- a/projects/neural_network/src/layers/repeat.rs
+++ b/projects/neural_network/src/layers/repeat.rs
@@ -1,7 +1,5 @@
 use std::marker::PhantomData;
 
-use ndarray::{Array1, Array2, Axis};
-
 use crate::matrix::{matrix_one_dim::MatrixOneDim, matrix_two_dim::MatrixTwoDim};
 
 use super::layer::Layer;

--- a/projects/neural_network/src/layers/repeat.rs
+++ b/projects/neural_network/src/layers/repeat.rs
@@ -1,45 +1,60 @@
+use std::marker::PhantomData;
+
 use ndarray::{Array1, Array2, Axis};
+
+use crate::matrix::{matrix_one_dim::MatrixOneDim, matrix_two_dim::MatrixTwoDim};
 
 use super::layer::Layer;
 
-struct Repeat {
+struct Repeat<M2, M1> {
     n: Option<usize>,
+    ph2: PhantomData<M2>,
+    ph1: PhantomData<M1>,
 }
 
-struct InputOfRepeatLayer {
-    input: Array1<f32>,
+struct InputOfRepeatLayer<M1> {
+    input: M1,
     n: usize,
 }
 
-struct DInputOfRepeatLayer {
-    dinput: Array1<f32>,
+struct DInputOfRepeatLayer<M1> {
+    dinput: M1,
 }
 
-struct OutputOfRepeatLayer {
-    out: Array2<f32>,
+struct OutputOfRepeatLayer<M2> {
+    out: M2,
 }
 
-impl Layer for Repeat {
-    type Input = InputOfRepeatLayer;
-    type Output = OutputOfRepeatLayer;
-    type DInput = DInputOfRepeatLayer;
+impl<M2, M1> Layer<M2, M1> for Repeat<M2, M1>
+where
+    M2: MatrixTwoDim<M1>,
+    M1: MatrixOneDim,
+{
+    type Input = InputOfRepeatLayer<M1>;
+    type Output = OutputOfRepeatLayer<M2>;
+    type DInput = DInputOfRepeatLayer<M1>;
 
     fn new() -> Self {
-        Self { n: None }
+        Self {
+            n: None,
+            ph2: PhantomData,
+            ph1: PhantomData,
+        }
     }
 
     fn forward(&mut self, input: Self::Input) -> Self::Output {
         let Self::Input { input, n } = input;
         self.n = Some(n);
+        let len = input.len();
         Self::Output {
-            out: input.broadcast((n, input.len())).unwrap().to_owned(),
+            out: M2::broadcast_1d_array(input, (n, len)),
         }
     }
 
     fn backward(&self, dout: Self::Output) -> Self::DInput {
         assert!(self.n.is_some());
         Self::DInput {
-            dinput: dout.out.sum_axis(Axis(0)).to_owned(),
+            dinput: dout.out.sum_axis_zero().to_owned(),
         }
     }
 }

--- a/projects/neural_network/src/layers/sigmoid.rs
+++ b/projects/neural_network/src/layers/sigmoid.rs
@@ -3,56 +3,74 @@
     ∂L/∂x = y(1-y)∂L/∂y
 */
 
+use std::marker::PhantomData;
+
 use ndarray::Array2;
+
+use crate::matrix::{matrix_one_dim::MatrixOneDim, matrix_two_dim::MatrixTwoDim};
 
 use super::layer::Layer;
 
-pub(crate) struct Sigmoid {
-    out: Option<Array2<f32>>,
+pub(crate) struct Sigmoid<M2, M1> {
+    out: Option<M2>,
+    ph: PhantomData<M1>,
 }
 
-pub(crate) struct InputOfSigmoidLayer {
-    input: Array2<f32>,
+pub(crate) struct InputOfSigmoidLayer<M2> {
+    input: M2,
 }
 
-impl From<Array2<f32>> for InputOfSigmoidLayer {
-    fn from(value: Array2<f32>) -> Self {
+impl<M2> From<M2> for InputOfSigmoidLayer<M2> {
+    fn from(value: M2) -> Self {
         Self { input: value }
     }
 }
 
-pub(crate) struct DInputOfSigmoidLayer {
-    dinput: Array2<f32>,
+pub(crate) struct DInputOfSigmoidLayer<M2> {
+    dinput: M2,
 }
 
-impl Into<Array2<f32>> for DInputOfSigmoidLayer {
-    fn into(self) -> Array2<f32> {
+impl<M2> DInputOfSigmoidLayer<M2> {
+    pub fn into_value(self) -> M2 {
         self.dinput
     }
 }
 
-pub(crate) struct OutputOfSigmoidLayer {
-    out: Array2<f32>,
-}
-
-impl From<Array2<f32>> for OutputOfSigmoidLayer {
-    fn from(value: Array2<f32>) -> Self {
-        Self { out: value }
+impl<M2> From<M2> for DInputOfSigmoidLayer<M2> {
+    fn from(value: M2) -> Self {
+        Self { dinput: value }
     }
 }
 
-impl Into<Array2<f32>> for OutputOfSigmoidLayer {
-    fn into(self) -> Array2<f32> {
+pub(crate) struct OutputOfSigmoidLayer<M2> {
+    out: M2,
+}
+
+impl<M2> OutputOfSigmoidLayer<M2> {
+    pub fn into_value(self) -> M2 {
         self.out
     }
 }
 
-impl Layer for Sigmoid {
-    type Input = InputOfSigmoidLayer;
-    type Output = OutputOfSigmoidLayer;
-    type DInput = DInputOfSigmoidLayer;
+impl<M2> From<M2> for OutputOfSigmoidLayer<M2> {
+    fn from(value: M2) -> Self {
+        Self { out: value }
+    }
+}
+
+impl<M2, M1> Layer<M2, M1> for Sigmoid<M2, M1>
+where
+    M2: MatrixTwoDim<M1>,
+    M1: MatrixOneDim,
+{
+    type Input = InputOfSigmoidLayer<M2>;
+    type Output = OutputOfSigmoidLayer<M2>;
+    type DInput = DInputOfSigmoidLayer<M2>;
     fn new() -> Self {
-        Self { out: None }
+        Self {
+            out: None,
+            ph: PhantomData,
+        }
     }
 
     fn forward(&mut self, input: Self::Input) -> Self::Output {
@@ -67,7 +85,7 @@ impl Layer for Sigmoid {
         let out = self.out.as_ref().unwrap();
         let Self::Output { out: dout } = dout;
 
-        let dinput = out * (Array2::ones(out.dim()) - out) * dout;
+        let dinput = out.clone() * (M2::ones_like(&out) - out.clone()) * dout;
         Self::DInput { dinput }
     }
 }
@@ -127,7 +145,7 @@ mod tests {
             .into_iter()
             .zip(expected)
             .for_each(|(dinput, expected)| {
-                assert_abs_diff_eq!(dinput, expected, epsilon = 1e-14);
+                assert_abs_diff_eq!(dinput, expected, epsilon = 1e-6);
             });
     }
 }

--- a/projects/neural_network/src/layers/sigmoid.rs
+++ b/projects/neural_network/src/layers/sigmoid.rs
@@ -5,8 +5,6 @@
 
 use std::marker::PhantomData;
 
-use ndarray::Array2;
-
 use crate::matrix::{matrix_one_dim::MatrixOneDim, matrix_two_dim::MatrixTwoDim};
 
 use super::layer::Layer;

--- a/projects/neural_network/src/layers/softmax_cross_entropy.rs
+++ b/projects/neural_network/src/layers/softmax_cross_entropy.rs
@@ -15,8 +15,6 @@
 
 use std::marker::PhantomData;
 
-use ndarray::{Array1, Array2, ArrayView1};
-
 use crate::matrix::{matrix_one_dim::MatrixOneDim, matrix_two_dim::MatrixTwoDim};
 
 use super::layer::Layer;

--- a/projects/neural_network/src/layers/sum.rs
+++ b/projects/neural_network/src/layers/sum.rs
@@ -1,7 +1,5 @@
 use std::marker::PhantomData;
 
-use ndarray::{Array1, Array2, Axis};
-
 use crate::matrix::{matrix_one_dim::MatrixOneDim, matrix_two_dim::MatrixTwoDim};
 
 use super::layer::Layer;

--- a/projects/neural_network/src/lib.rs
+++ b/projects/neural_network/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod dataset;
 pub(crate) mod layers;
+pub mod matrix;
 pub mod network;
 pub mod optimizer;
 pub mod trainer;

--- a/projects/neural_network/src/matrix/matrix_one_dim.rs
+++ b/projects/neural_network/src/matrix/matrix_one_dim.rs
@@ -1,0 +1,72 @@
+use std::ops::{Add, Div, Mul, Sub};
+
+use ndarray::Array1;
+
+pub trait MatrixOneDim:
+    Add<Output = Self>
+    + Sub<Output = Self>
+    + Mul<f32, Output = Self>
+    + Div<f32, Output = Self>
+    + Clone
+    + From<Vec<f32>>
+{
+    fn max_value(&self) -> f32;
+    fn mapv_into<F>(self, f: F) -> Self
+    where
+        F: FnMut(f32) -> f32;
+    fn sum(&self) -> f32;
+    fn len(&self) -> usize;
+    fn zeros(len: usize) -> Self;
+    fn find_index<F>(&self, f: F) -> Option<usize>
+    where
+        F: FnMut(f32) -> bool;
+    fn into_one_hot(self) -> Self;
+}
+
+impl MatrixOneDim for Array1<f32> {
+    fn max_value(&self) -> f32 {
+        *self.iter().max_by(|&a, &b| a.total_cmp(b)).unwrap()
+    }
+
+    fn mapv_into<F>(self, f: F) -> Self
+    where
+        F: FnMut(f32) -> f32,
+    {
+        self.mapv_into(f)
+    }
+
+    fn sum(&self) -> f32 {
+        self.sum()
+    }
+
+    fn len(&self) -> usize {
+        self.len()
+    }
+
+    fn zeros(len: usize) -> Self {
+        Array1::zeros(len)
+    }
+
+    fn find_index<F>(&self, mut f: F) -> Option<usize>
+    where
+        F: FnMut(f32) -> bool,
+    {
+        self.iter()
+            .enumerate()
+            .find(|&(_index, &v)| (f)(v))
+            .map(|(index, _)| index)
+    }
+
+    fn into_one_hot(self) -> Self {
+        let max_value = self.max_value();
+        let mut one_hot = vec![0.; self.len()];
+        let index = self
+            .iter()
+            .enumerate()
+            .find(|&(_index, &v)| v == max_value)
+            .map(|(index, _)| index)
+            .unwrap();
+        one_hot[index] = 1.;
+        Self::from(one_hot)
+    }
+}

--- a/projects/neural_network/src/matrix/matrix_two_dim.rs
+++ b/projects/neural_network/src/matrix/matrix_two_dim.rs
@@ -1,6 +1,6 @@
 use std::ops::{Add, Div, Mul, Sub};
 
-use ndarray::{Array1, Array2, ArrayView1, Axis, ShapeBuilder, Zip};
+use ndarray::{Array1, Array2, Axis};
 use ndarray_rand::{rand_distr::Normal, RandomExt};
 
 use super::matrix_one_dim::MatrixOneDim;
@@ -17,7 +17,7 @@ where
     M1: MatrixOneDim,
 {
     fn dot(&self, rhs: &Self) -> Self;
-    fn t(&mut self) -> Self;
+    fn t(&self) -> Self;
     fn sum_axis_zero(&self) -> M1;
     fn sum(&self) -> f32 {
         self.sum_axis_zero().sum()
@@ -44,8 +44,8 @@ impl MatrixTwoDim<Array1<f32>> for Array2<f32> {
         self.dot(rhs)
     }
 
-    fn t(&mut self) -> Self {
-        self.t()
+    fn t(&self) -> Self {
+        self.t().to_owned()
     }
 
     fn sum_axis_zero(&self) -> Array1<f32> {
@@ -71,7 +71,7 @@ impl MatrixTwoDim<Array1<f32>> for Array2<f32> {
         self.dim()
     }
 
-    fn mapv_into_for_each_rows<F>(mut self, mut f: F) -> Self
+    fn mapv_into_for_each_rows<F>(self, mut f: F) -> Self
     where
         F: FnMut(Array1<f32>) -> Array1<f32>,
     {

--- a/projects/neural_network/src/matrix/matrix_two_dim.rs
+++ b/projects/neural_network/src/matrix/matrix_two_dim.rs
@@ -1,0 +1,119 @@
+use std::ops::{Add, Div, Mul, Sub};
+
+use ndarray::{Array1, Array2, ArrayView1, Axis, ShapeBuilder, Zip};
+use ndarray_rand::{rand_distr::Normal, RandomExt};
+
+use super::matrix_one_dim::MatrixOneDim;
+
+pub trait MatrixTwoDim<M1>:
+    Add<Output = Self>
+    + Add<M1, Output = Self>
+    + Sub<Output = Self>
+    + Mul<Output = Self>
+    + Mul<f32, Output = Self>
+    + Div<f32, Output = Self>
+    + Clone
+where
+    M1: MatrixOneDim,
+{
+    fn dot(&self, rhs: &Self) -> Self;
+    fn t(&mut self) -> Self;
+    fn sum_axis_zero(&self) -> M1;
+    fn sum(&self) -> f32 {
+        self.sum_axis_zero().sum()
+    }
+    fn mapv_into<F>(self, f: F) -> Self
+    where
+        F: FnMut(f32) -> f32;
+    fn ones_like(&self) -> Self;
+    fn zeros_like(&self) -> Self;
+    fn dim(&self) -> (usize, usize);
+    fn mapv_into_for_each_rows<F>(self, f: F) -> Self
+    where
+        F: FnMut(M1) -> M1;
+    fn from_1d_arrays(arrays: Vec<M1>) -> Self;
+    fn broadcast_1d_array(array: M1, shape: (usize, usize)) -> Self;
+    fn zip_with<F>(&self, rhs: &Self, f: F) -> Self
+    where
+        F: FnMut(&f32, &f32) -> f32;
+    fn random_normal(dim: (usize, usize), mean: f32, std_dev: f32) -> Self;
+}
+
+impl MatrixTwoDim<Array1<f32>> for Array2<f32> {
+    fn dot(&self, rhs: &Self) -> Self {
+        self.dot(rhs)
+    }
+
+    fn t(&mut self) -> Self {
+        self.t()
+    }
+
+    fn sum_axis_zero(&self) -> Array1<f32> {
+        self.sum_axis(Axis(0))
+    }
+
+    fn mapv_into<F>(self, f: F) -> Self
+    where
+        F: FnMut(f32) -> f32,
+    {
+        self.mapv_into(f)
+    }
+
+    fn ones_like(&self) -> Self {
+        Array2::ones(self.dim())
+    }
+
+    fn zeros_like(&self) -> Self {
+        Array2::zeros(self.dim())
+    }
+
+    fn dim(&self) -> (usize, usize) {
+        self.dim()
+    }
+
+    fn mapv_into_for_each_rows<F>(mut self, mut f: F) -> Self
+    where
+        F: FnMut(Array1<f32>) -> Array1<f32>,
+    {
+        let (height, width) = self.dim();
+        let flattened: Array1<f32> = self
+            .rows()
+            .into_iter()
+            .flat_map(|row| (f)(row.to_owned()))
+            .collect();
+        flattened.into_shape((height, width)).unwrap()
+    }
+
+    fn from_1d_arrays(arrays: Vec<Array1<f32>>) -> Self {
+        // ソースに１つ以上の１次元配列が含まれることを要請
+        let width = arrays.len();
+        assert!(width > 0);
+
+        // すべての1次元配列の長さが等しいことを要請
+        let height = arrays[0].len();
+        assert!(arrays.iter().all(|array| { array.len() == height }));
+
+        // １次元配列をすべて連結
+        let flattened: Array1<f32> = arrays.into_iter().flat_map(|row| row.to_vec()).collect();
+
+        // 連結した１次元配列を２次元配列に変換
+        let output = flattened.into_shape((width, height)).unwrap();
+        output
+    }
+
+    fn broadcast_1d_array(array: Array1<f32>, shape: (usize, usize)) -> Self {
+        array.broadcast(shape).unwrap().to_owned()
+    }
+
+    fn zip_with<F>(&self, rhs: &Self, mut f: F) -> Self
+    where
+        F: FnMut(&f32, &f32) -> f32,
+    {
+        let flattened: Array1<f32> = self.into_iter().zip(rhs).map(|(s, r)| (f)(s, r)).collect();
+        flattened.into_shape(self.dim()).unwrap()
+    }
+
+    fn random_normal(dim: (usize, usize), mean: f32, std_dev: f32) -> Self {
+        Array2::random(dim, Normal::new(mean, std_dev).unwrap())
+    }
+}

--- a/projects/neural_network/src/matrix/mod.rs
+++ b/projects/neural_network/src/matrix/mod.rs
@@ -1,0 +1,2 @@
+pub mod matrix_one_dim;
+pub mod matrix_two_dim;

--- a/projects/neural_network/src/network/layers/affine.rs
+++ b/projects/neural_network/src/network/layers/affine.rs
@@ -2,26 +2,33 @@ use std::ops::{Add, Mul};
 
 use ndarray::{Array1, Array2};
 
-use crate::layers::{
-    affine::{Affine, DInputOfAffineLayer, InputOfAffineLayer, OutputOfAffineLayer},
-    layer::Layer,
+use crate::{
+    layers::{
+        affine::{Affine, DInputOfAffineLayer, InputOfAffineLayer, OutputOfAffineLayer},
+        layer::Layer,
+    },
+    matrix::{matrix_one_dim::MatrixOneDim, matrix_two_dim::MatrixTwoDim},
 };
 
-use super::layer::{LayerBase, IntermediateLayer};
+use super::layer::{IntermediateLayer, LayerBase};
 
-pub(crate) struct AffineLayer {
-    affine: Affine,
-    params: ParamsOfAffineLayer,
-    grads: ParamsOfAffineLayer,
+pub(crate) struct AffineLayer<M2, M1> {
+    affine: Affine<M2, M1>,
+    params: ParamsOfAffineLayer<M2, M1>,
+    grads: ParamsOfAffineLayer<M2, M1>,
 }
 
 #[derive(Clone)]
-pub struct ParamsOfAffineLayer {
-    pub(crate) w: Array2<f32>,
-    pub(crate) b: Array1<f32>,
+pub struct ParamsOfAffineLayer<M2, M1> {
+    pub(crate) w: M2,
+    pub(crate) b: M1,
 }
 
-impl Add for ParamsOfAffineLayer {
+impl<M2, M1> Add for ParamsOfAffineLayer<M2, M1>
+where
+    M2: MatrixTwoDim<M1>,
+    M1: MatrixOneDim,
+{
     type Output = Self;
 
     fn add(self, rhs: Self) -> Self::Output {
@@ -32,7 +39,11 @@ impl Add for ParamsOfAffineLayer {
     }
 }
 
-impl Mul<f32> for ParamsOfAffineLayer {
+impl<M2, M1> Mul<f32> for ParamsOfAffineLayer<M2, M1>
+where
+    M2: MatrixTwoDim<M1>,
+    M1: MatrixOneDim,
+{
     type Output = Self;
 
     fn mul(self, rhs: f32) -> Self::Output {
@@ -43,14 +54,18 @@ impl Mul<f32> for ParamsOfAffineLayer {
     }
 }
 
-impl LayerBase for AffineLayer {
-    type Params = ParamsOfAffineLayer;
+impl<M2, M1> LayerBase for AffineLayer<M2, M1>
+where
+    M2: MatrixTwoDim<M1>,
+    M1: MatrixOneDim,
+{
+    type Params = ParamsOfAffineLayer<M2, M1>;
 
     fn new(params: Self::Params) -> Self {
         let affine = Affine::new();
         let grads = ParamsOfAffineLayer {
-            w: Array2::zeros(params.w.dim()),
-            b: Array1::zeros(params.b.dim()),
+            w: M2::zeros_like(&params.w),
+            b: M1::zeros(params.b.len()),
         };
         Self {
             affine,
@@ -64,18 +79,22 @@ impl LayerBase for AffineLayer {
     }
 }
 
-impl IntermediateLayer for AffineLayer {
-    fn forward(&mut self, input: Array2<f32>) -> Array2<f32> {
+impl<M2, M1> IntermediateLayer<M2, M1> for AffineLayer<M2, M1>
+where
+    M2: MatrixTwoDim<M1>,
+    M1: MatrixOneDim,
+{
+    fn forward(&mut self, input: M2) -> M2 {
         self.affine
             .forward(InputOfAffineLayer {
                 x: input,
                 a: self.params.w.clone(),
                 b: self.params.b.clone(),
             })
-            .into()
+            .into_value()
     }
 
-    fn backward(&mut self, dout: Array2<f32>) -> Array2<f32> {
+    fn backward(&mut self, dout: M2) -> M2 {
         let DInputOfAffineLayer { dx, da, db } =
             self.affine.backward(OutputOfAffineLayer::from(dout));
         self.grads.w = da;

--- a/projects/neural_network/src/network/layers/affine.rs
+++ b/projects/neural_network/src/network/layers/affine.rs
@@ -1,7 +1,5 @@
 use std::ops::{Add, Mul};
 
-use ndarray::{Array1, Array2};
-
 use crate::{
     layers::{
         affine::{Affine, DInputOfAffineLayer, InputOfAffineLayer, OutputOfAffineLayer},

--- a/projects/neural_network/src/network/layers/layer.rs
+++ b/projects/neural_network/src/network/layers/layer.rs
@@ -1,5 +1,3 @@
-use ndarray::Array2;
-
 use crate::matrix::{matrix_one_dim::MatrixOneDim, matrix_two_dim::MatrixTwoDim};
 
 pub(crate) trait LayerBase {

--- a/projects/neural_network/src/network/layers/layer.rs
+++ b/projects/neural_network/src/network/layers/layer.rs
@@ -1,17 +1,27 @@
 use ndarray::Array2;
 
+use crate::matrix::{matrix_one_dim::MatrixOneDim, matrix_two_dim::MatrixTwoDim};
+
 pub(crate) trait LayerBase {
     type Params;
     fn new(params: Self::Params) -> Self;
     fn params_and_grads(&mut self) -> (&mut Self::Params, &Self::Params);
 }
 
-pub(crate) trait IntermediateLayer: LayerBase {
-    fn forward(&mut self, input: Array2<f32>) -> Array2<f32>;
-    fn backward(&mut self, dout: Array2<f32>) -> Array2<f32>;
+pub(crate) trait IntermediateLayer<M2, M1>: LayerBase
+where
+    M2: MatrixTwoDim<M1>,
+    M1: MatrixOneDim,
+{
+    fn forward(&mut self, input: M2) -> M2;
+    fn backward(&mut self, dout: M2) -> M2;
 }
 
-pub(crate) trait LossLayer: LayerBase {
-    fn forward(&mut self, input: Array2<f32>, one_hot_labels: Array2<f32>) -> f32;
-    fn backward(&mut self, dout: f32) -> Array2<f32>;
+pub(crate) trait LossLayer<M2, M1>: LayerBase
+where
+    M2: MatrixTwoDim<M1>,
+    M1: MatrixOneDim,
+{
+    fn forward(&mut self, input: M2, one_hot_labels: M2) -> f32;
+    fn backward(&mut self, dout: f32) -> M2;
 }

--- a/projects/neural_network/src/network/layers/relu.rs
+++ b/projects/neural_network/src/network/layers/relu.rs
@@ -1,21 +1,28 @@
 use ndarray::Array2;
 
-use crate::layers::{
-    layer::Layer,
-    relu::{InputOfReLULayer, OutputOfReLULayer, ReLU},
+use crate::{
+    layers::{
+        layer::Layer,
+        relu::{InputOfReLULayer, OutputOfReLULayer, ReLU},
+    },
+    matrix::{matrix_one_dim::MatrixOneDim, matrix_two_dim::MatrixTwoDim},
 };
 
-use super::layer::{LayerBase, IntermediateLayer};
+use super::layer::{IntermediateLayer, LayerBase};
 
-pub(crate) struct ReLULayer {
-    relu: ReLU,
+pub(crate) struct ReLULayer<M2, M1> {
+    relu: ReLU<M2, M1>,
     params: ParamsOfReLULayer,
     grads: ParamsOfReLULayer,
 }
 
 pub(crate) struct ParamsOfReLULayer();
 
-impl LayerBase for ReLULayer {
+impl<M2, M1> LayerBase for ReLULayer<M2, M1>
+where
+    M2: MatrixTwoDim<M1>,
+    M1: MatrixOneDim,
+{
     type Params = ParamsOfReLULayer;
 
     fn new(params: Self::Params) -> Self {
@@ -33,16 +40,16 @@ impl LayerBase for ReLULayer {
     }
 }
 
-impl IntermediateLayer for ReLULayer {
-    fn forward(&mut self, input: Array2<f32>) -> Array2<f32> {
-        self.relu
-            .forward(InputOfReLULayer::from(input))
-            .into()
+impl<M2, M1> IntermediateLayer<M2, M1> for ReLULayer<M2, M1>
+where
+    M2: MatrixTwoDim<M1>,
+    M1: MatrixOneDim,
+{
+    fn forward(&mut self, input: M2) -> M2 {
+        self.relu.forward(InputOfReLULayer::from(input)).into_value()
     }
 
-    fn backward(&mut self, dout: Array2<f32>) -> Array2<f32> {
-        self.relu
-            .backward(OutputOfReLULayer::from(dout))
-            .into()
+    fn backward(&mut self, dout: M2) -> M2 {
+        self.relu.backward(OutputOfReLULayer::from(dout)).into_value()
     }
 }

--- a/projects/neural_network/src/network/layers/relu.rs
+++ b/projects/neural_network/src/network/layers/relu.rs
@@ -1,5 +1,3 @@
-use ndarray::Array2;
-
 use crate::{
     layers::{
         layer::Layer,

--- a/projects/neural_network/src/network/layers/sigmoid.rs
+++ b/projects/neural_network/src/network/layers/sigmoid.rs
@@ -1,21 +1,28 @@
 use ndarray::Array2;
 
-use crate::layers::{
-    layer::Layer,
-    sigmoid::{InputOfSigmoidLayer, OutputOfSigmoidLayer, Sigmoid},
+use crate::{
+    layers::{
+        layer::Layer,
+        sigmoid::{InputOfSigmoidLayer, OutputOfSigmoidLayer, Sigmoid},
+    },
+    matrix::{matrix_one_dim::MatrixOneDim, matrix_two_dim::MatrixTwoDim},
 };
 
-use super::layer::{LayerBase, IntermediateLayer};
+use super::layer::{IntermediateLayer, LayerBase};
 
-pub(crate) struct SigmoidLayer {
-    sigmoid: Sigmoid,
+pub(crate) struct SigmoidLayer<M2, M1> {
+    sigmoid: Sigmoid<M2, M1>,
     params: ParamsOfSigmoidLayer,
     grads: ParamsOfSigmoidLayer,
 }
 
 pub(crate) struct ParamsOfSigmoidLayer();
 
-impl LayerBase for SigmoidLayer {
+impl<M2, M1> LayerBase for SigmoidLayer<M2, M1>
+where
+    M2: MatrixTwoDim<M1>,
+    M1: MatrixOneDim,
+{
     type Params = ParamsOfSigmoidLayer;
 
     fn new(params: Self::Params) -> Self {
@@ -33,16 +40,20 @@ impl LayerBase for SigmoidLayer {
     }
 }
 
-impl IntermediateLayer for SigmoidLayer {
-    fn forward(&mut self, input: Array2<f32>) -> Array2<f32> {
+impl<M2, M1> IntermediateLayer<M2, M1> for SigmoidLayer<M2, M1>
+where
+    M2: MatrixTwoDim<M1>,
+    M1: MatrixOneDim,
+{
+    fn forward(&mut self, input: M2) -> M2 {
         self.sigmoid
             .forward(InputOfSigmoidLayer::from(input))
-            .into()
+            .into_value()
     }
 
-    fn backward(&mut self, dout: Array2<f32>) -> Array2<f32> {
+    fn backward(&mut self, dout: M2) -> M2 {
         self.sigmoid
             .backward(OutputOfSigmoidLayer::from(dout))
-            .into()
+            .into_value()
     }
 }

--- a/projects/neural_network/src/network/layers/sigmoid.rs
+++ b/projects/neural_network/src/network/layers/sigmoid.rs
@@ -1,5 +1,3 @@
-use ndarray::Array2;
-
 use crate::{
     layers::{
         layer::Layer,

--- a/projects/neural_network/src/network/layers/softmax_cross_entropy.rs
+++ b/projects/neural_network/src/network/layers/softmax_cross_entropy.rs
@@ -1,23 +1,30 @@
 use ndarray::Array2;
 
-use crate::layers::{
-    layer::Layer,
-    softmax_cross_entropy::{
-        InputOfSoftmaxCrossEntropyLayer, OutputOfSoftmaxCrossEntropyLayer, SoftmaxCrossEntropy,
+use crate::{
+    layers::{
+        layer::Layer,
+        softmax_cross_entropy::{
+            InputOfSoftmaxCrossEntropyLayer, OutputOfSoftmaxCrossEntropyLayer, SoftmaxCrossEntropy,
+        },
     },
+    matrix::{matrix_one_dim::MatrixOneDim, matrix_two_dim::MatrixTwoDim},
 };
 
 use super::layer::{LayerBase, LossLayer};
 
-pub(crate) struct SoftmaxCrossEntropyLayer {
-    softmax_cross_entropy: SoftmaxCrossEntropy,
+pub(crate) struct SoftmaxCrossEntropyLayer<M2, M1> {
+    softmax_cross_entropy: SoftmaxCrossEntropy<M2, M1>,
     params: ParamsOfSoftmaxCrossEntropyLayer,
     grads: ParamsOfSoftmaxCrossEntropyLayer,
 }
 
 pub(crate) struct ParamsOfSoftmaxCrossEntropyLayer();
 
-impl LayerBase for SoftmaxCrossEntropyLayer {
+impl<M2, M1> LayerBase for SoftmaxCrossEntropyLayer<M2, M1>
+where
+    M2: MatrixTwoDim<M1>,
+    M1: MatrixOneDim,
+{
     type Params = ParamsOfSoftmaxCrossEntropyLayer;
 
     fn new(params: Self::Params) -> Self {
@@ -34,16 +41,20 @@ impl LayerBase for SoftmaxCrossEntropyLayer {
     }
 }
 
-impl LossLayer for SoftmaxCrossEntropyLayer {
-    fn forward(&mut self, input: Array2<f32>, one_hot_labels: Array2<f32>) -> f32 {
+impl<M2, M1> LossLayer<M2, M1> for SoftmaxCrossEntropyLayer<M2, M1>
+where
+    M2: MatrixTwoDim<M1>,
+    M1: MatrixOneDim,
+{
+    fn forward(&mut self, input: M2, one_hot_labels: M2) -> f32 {
         self.softmax_cross_entropy
             .forward(InputOfSoftmaxCrossEntropyLayer::from(input, one_hot_labels))
-            .into()
+            .into_value()
     }
 
-    fn backward(&mut self, dout: f32) -> Array2<f32> {
+    fn backward(&mut self, dout: f32) -> M2 {
         self.softmax_cross_entropy
             .backward(OutputOfSoftmaxCrossEntropyLayer::from(dout))
-            .into()
+            .into_value()
     }
 }

--- a/projects/neural_network/src/network/layers/softmax_cross_entropy.rs
+++ b/projects/neural_network/src/network/layers/softmax_cross_entropy.rs
@@ -1,5 +1,3 @@
-use ndarray::Array2;
-
 use crate::{
     layers::{
         layer::Layer,

--- a/projects/neural_network/src/network/network.rs
+++ b/projects/neural_network/src/network/network.rs
@@ -2,9 +2,9 @@ use ndarray::Array2;
 
 use crate::optimizer::optimizer::Optimizer;
 
-pub trait Network {
-    fn predict(&mut self, input: Array2<f32>) -> Array2<f32>;
-    fn forward(&mut self, input: Array2<f32>, one_hot_labels: Array2<f32>) -> f32;
-    fn backward(&mut self, dout: f32) -> Array2<f32>;
+pub trait Network<M2, M1> {
+    fn predict(&mut self, input: M2) -> M2;
+    fn forward(&mut self, input: M2, one_hot_labels: M2) -> f32;
+    fn backward(&mut self, dout: f32) -> M2;
     fn update<T: Optimizer>(&mut self, optimizer: &T);
 }

--- a/projects/neural_network/src/network/network.rs
+++ b/projects/neural_network/src/network/network.rs
@@ -1,5 +1,3 @@
-use ndarray::Array2;
-
 use crate::optimizer::optimizer::Optimizer;
 
 pub trait Network<M2, M1> {

--- a/projects/neural_network/src/network/simple_network.rs
+++ b/projects/neural_network/src/network/simple_network.rs
@@ -1,12 +1,15 @@
-use ndarray::{Array, Array2};
+use ndarray::{Array, Array1, Array2};
 use ndarray_rand::{rand_distr::Normal, RandomExt};
 
-use crate::optimizer::optimizer::Optimizer;
+use crate::{
+    matrix::{matrix_one_dim::MatrixOneDim, matrix_two_dim::MatrixTwoDim},
+    optimizer::optimizer::Optimizer,
+};
 
 use super::{
     layers::{
         affine::{AffineLayer, ParamsOfAffineLayer},
-        layer::{LayerBase, LossLayer, IntermediateLayer},
+        layer::{IntermediateLayer, LayerBase, LossLayer},
         relu::{ParamsOfReLULayer, ReLULayer},
         sigmoid::{ParamsOfSigmoidLayer, SigmoidLayer},
         softmax_cross_entropy::{ParamsOfSoftmaxCrossEntropyLayer, SoftmaxCrossEntropyLayer},
@@ -18,15 +21,15 @@ use super::{
 const MEAN_DISTR: f32 = 0.;
 const STD_DEV_DISTR: f32 = 0.01;
 
-enum HiddenLayer {
-    Affine(AffineLayer),
-    Sigmoid(SigmoidLayer),
-    ReLU(ReLULayer),
+enum HiddenLayer<M2, M1> {
+    Affine(AffineLayer<M2, M1>),
+    Sigmoid(SigmoidLayer<M2, M1>),
+    ReLU(ReLULayer<M2, M1>),
 }
 
-pub struct SimpleNetwork {
-    layers: Vec<HiddenLayer>,
-    loss_layer: SoftmaxCrossEntropyLayer,
+pub struct SimpleNetwork<M2, M1> {
+    layers: Vec<HiddenLayer<M2, M1>>,
+    loss_layer: SoftmaxCrossEntropyLayer<M2, M1>,
 }
 
 pub enum Activation {
@@ -34,23 +37,30 @@ pub enum Activation {
     ReLU,
 }
 
-impl SimpleNetwork {
+impl<M2, M1> SimpleNetwork<M2, M1>
+where
+    M2: MatrixTwoDim<M1>,
+    M1: MatrixOneDim,
+{
     pub fn new(
         input_size: usize,
         hidden_sizes: Vec<usize>,
         output_size: usize,
         activation: Activation,
     ) -> Self {
-        let distribution = Normal::new(MEAN_DISTR, STD_DEV_DISTR).unwrap();
-
         let mut layers = vec![];
 
         let last_layer_size =
             hidden_sizes
                 .into_iter()
                 .fold(input_size, |last_layer_size, current_layer_size| {
-                    let weight = Array::random((last_layer_size, current_layer_size), distribution);
-                    let bias = Array::zeros(current_layer_size);
+                    // TODO: 重みとバイアスの初期化を M2, M1 に要請する
+                    let weight = M2::random_normal(
+                        (last_layer_size, current_layer_size),
+                        MEAN_DISTR,
+                        STD_DEV_DISTR,
+                    );
+                    let bias = M1::zeros(current_layer_size);
 
                     layers.push(HiddenLayer::Affine(AffineLayer::new(ParamsOfAffineLayer {
                         w: weight,
@@ -71,8 +81,8 @@ impl SimpleNetwork {
                     current_layer_size
                 });
 
-        let weight = Array::random((last_layer_size, output_size), distribution);
-        let bias = Array::zeros(output_size);
+        let weight = M2::random_normal((last_layer_size, output_size), MEAN_DISTR, STD_DEV_DISTR);
+        let bias = M1::zeros(output_size);
 
         layers.push(HiddenLayer::Affine(AffineLayer::new(ParamsOfAffineLayer {
             w: weight,
@@ -85,7 +95,12 @@ impl SimpleNetwork {
         }
     }
 
-    fn params_and_grads(&mut self) -> Vec<(&mut ParamsOfAffineLayer, &ParamsOfAffineLayer)> {
+    fn params_and_grads(
+        &mut self,
+    ) -> Vec<(
+        &mut ParamsOfAffineLayer<M2, M1>,
+        &ParamsOfAffineLayer<M2, M1>,
+    )> {
         let mut params_and_grads = vec![];
         for layer in &mut self.layers {
             match layer {
@@ -100,8 +115,12 @@ impl SimpleNetwork {
     }
 }
 
-impl Network for SimpleNetwork {
-    fn predict(&mut self, input: Array2<f32>) -> Array2<f32> {
+impl<M2, M1> Network<M2, M1> for SimpleNetwork<M2, M1>
+where
+    M2: MatrixTwoDim<M1>,
+    M1: MatrixOneDim,
+{
+    fn predict(&mut self, input: M2) -> M2 {
         let mut input = input;
         for layer in &mut self.layers {
             match layer {
@@ -119,13 +138,13 @@ impl Network for SimpleNetwork {
         input
     }
 
-    fn forward(&mut self, input: Array2<f32>, one_hot_labels: Array2<f32>) -> f32 {
+    fn forward(&mut self, input: M2, one_hot_labels: M2) -> f32 {
         let score = self.predict(input);
         let loss = self.loss_layer.forward(score, one_hot_labels);
         loss
     }
 
-    fn backward(&mut self, dout: f32) -> Array2<f32> {
+    fn backward(&mut self, dout: f32) -> M2 {
         let mut dout = self.loss_layer.backward(dout);
         for layer in self.layers.iter_mut().rev() {
             match layer {

--- a/projects/neural_network/src/network/simple_network.rs
+++ b/projects/neural_network/src/network/simple_network.rs
@@ -1,6 +1,3 @@
-use ndarray::{Array, Array1, Array2};
-use ndarray_rand::{rand_distr::Normal, RandomExt};
-
 use crate::{
     matrix::{matrix_one_dim::MatrixOneDim, matrix_two_dim::MatrixTwoDim},
     optimizer::optimizer::Optimizer,


### PR DESCRIPTION
- ndarray の利用箇所を抽象化して、`MatrixTwoDim<M1>` と `MatrixOneDim` というトレイトを利用するように変更
- このトレイトを実装すれば、他のライブラリも利用できるようになったはず
- ついでに、`softmax_cross_entropy` のテストコードを修正